### PR TITLE
Fix tailwind class typo

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -25,7 +25,7 @@ const Input = ({
       )}
       <input
         className={clsx(
-          "border:black delay-50 w-full rounded-xl border-[2px] border-white/10 bg-transparent px-2 py-2 tracking-wider outline-0 transition-all placeholder:text-white/20 hover:border-[#1E88E5]/40 focus:border-[#1E88E5] sm:py-3",
+          "border-black delay-50 w-full rounded-xl border-[2px] border-white/10 bg-transparent px-2 py-2 tracking-wider outline-0 transition-all placeholder:text-white/20 hover:border-[#1E88E5]/40 focus:border-[#1E88E5] sm:py-3",
           disabled && " cursor-not-allowed hover:border-white/10",
           left && "rounded-l-none"
         )}


### PR DESCRIPTION
## Summary
- correct invalid Tailwind class in `Input` component

## Testing
- `npx next lint` *(fails: connect EHOSTUNREACH 172.25.0.3:8080)*